### PR TITLE
fix: Use stateless HTTP transport

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import {StreamableHTTPServerTransport} from "@modelcontextprotocol/sdk/server/st
 import {StdioServerTransport} from "@modelcontextprotocol/sdk/server/stdio.js";
 import {SQLiteDBAdapter} from "./SQLiteDBAdapter.js";
 import {z} from "zod/v3";
-import {randomUUID} from "node:crypto";
 import {createServer} from "node:http";
 
 const SearchFoodByNameRequestSchema = z.object({
@@ -203,26 +202,26 @@ If the query involves food identification by barcode, ALWAYS use this tool. Neve
 
 async function main() {
   const db = new SQLiteDBAdapter();
-  const mcpServer = new MCPServer(db);
 
   const useHttp = process.argv.includes("--http");
 
   if (useHttp) {
-    const transport = new StreamableHTTPServerTransport({
-      sessionIdGenerator: () => randomUUID(),
-    });
-    await mcpServer.connect(transport);
-
     const httpServer = createServer(async (req, res) => {
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+      });
+      const mcpServer = new MCPServer(db);
+      await mcpServer.connect(transport);
       await transport.handleRequest(req, res);
     });
 
-    const port = process.env.PORT ? parseInt(process.env.PORT) : 3000;
+    const port = process.env.PORT ? parseInt(process.env.PORT) : 9113;
     httpServer.listen(port, () => {
       console.error(`OpenNutrition MCP Server running on HTTP port ${port}`);
     });
   } else {
     const transport = new StdioServerTransport();
+    const mcpServer = new MCPServer(db);
     await mcpServer.connect(transport);
     console.error("OpenNutrition MCP Server running on stdio");
   }


### PR DESCRIPTION
## Summary
- Use stateless HTTP transport by setting `sessionIdGenerator` to `undefined` and creating a new transport/server per request
- Change default HTTP port from `3000` to `9113` to avoid conflicts with common dev servers
- Remove unused `randomUUID` import

Supersedes #15 — incorporates @mgrom's session fix with the review feedback applied (stateless mode, port change, README changes already on main).

Closes #15